### PR TITLE
change fail icon to a red X, use yellow triangle for failed groups

### DIFF
--- a/Window.ahk
+++ b/Window.ahk
@@ -7,10 +7,11 @@ class YunitWindow
         Gui, Yunit:Add, Text, x0 y0 h30 vYunitWindowTitle Center, Test Results
         
         hImageList := IL_Create()
+        IL_Add(hImageList,"shell32.dll",132) ;red X
         IL_Add(hImageList,"shell32.dll",78) ;yellow triangle with exclamation mark
         IL_Add(hImageList,"shell32.dll",138) ;green circle with arrow facing right
         IL_Add(hImageList,"shell32.dll",135) ;two sheets of paper
-        this.icons := {fail: "Icon1", pass: "Icon2", detail: "Icon3"}
+        this.icons := {fail: "Icon1", issue: "Icon2", pass: "Icon3", detail: "Icon4"}
         
         Gui, Yunit:Font, s10
         Gui, Yunit:Add, TreeView, x10 y30 vYunitWindowEntries ImageList%hImageList%
@@ -49,7 +50,7 @@ class YunitWindow
             pos := 1
             while (pos)
             {
-                TV_Modify(this.Categories[key], this.icons.fail)
+                TV_Modify(this.Categories[key], this.icons.issue)
                 pos := InStr(key, ".", false, 0, 1)
                 key := SubStr(key, 1, pos-1)
             }


### PR DESCRIPTION
You guys are using a yellow triangle to denote a failed test. But the problem is, you also use this yellow triangle for the groups/categories as well. This misleads the user as to how many tests actually failed. When you run the Example.ahk file, a quick glace at the gui might lead you to think there are 5 failed tests, when in fact there are only 2:

![Imgur](http://i.imgur.com/uv5MhiQ.png)

I've made a change to show the failed tests as a Red X, and left the failed groups as the yellow exclamation. This allows you to easily see the difference:

![Imgur](http://i.imgur.com/FqAjKt1.png)
