### PR TITLE
change statusbar color to green/red depending upon test results

### DIFF
--- a/Window.ahk
+++ b/Window.ahk
@@ -2,7 +2,7 @@ class YunitWindow
 {
     __new(instance)
     {
-        global YunitWindowTitle, YunitWindowEntries
+        global YunitWindowTitle, YunitWindowEntries, YunitWindowStatusBar
         Gui, Yunit:Font, s16, Arial
         Gui, Yunit:Add, Text, x0 y0 h30 vYunitWindowTitle Center, Test Results
         
@@ -16,7 +16,7 @@ class YunitWindow
         Gui, Yunit:Add, TreeView, x10 y30 vYunitWindowEntries ImageList%hImageList%
         
         Gui, Yunit:Font, s8
-        Gui, Yunit:Add, StatusBar
+        Gui, Yunit:Add, StatusBar, vYunitWindowStatusBar -Theme BackgroundGreen
         Gui, Yunit:+Resize +MinSize320x200
         Gui, Yunit:Show, w500 h400, Yunit Testing
         Gui, Yunit:+LastFound
@@ -45,6 +45,7 @@ class YunitWindow
         {
             hChildNode := TV_Add(TestName,Parent,this.icons.fail)
             TV_Add("Line #" result.line ": " result.message,hChildNode,this.icons.detail)
+            GuiControl, Yunit: +BackgroundRed, YunitWindowStatusBar
             key := category
             pos := 1
             while (pos)


### PR DESCRIPTION
Its often useful to have a very quick visual confirmation if all of your tests have passed or failed. You guys had a StatusBar control added to the GUI that was unused. So I found a use for it. :)

Also, when the number of tests grow large, the TreeView control also grows large. Normally the GUI will scroll the TreeView to the bottom. This causes only the last tests to get displayed by default, requiring you to scroll up to find a potential failing test. 

Without the StatusBar colored red, you would see all green icons and might think that the tests have passed at first glance:
![Imgur](http://i.imgur.com/jExu56h.png)

You would need to specifically scroll up to see the failed tests:
![Imgur](http://i.imgur.com/z7HXDNZ.png)
