### PR TITLE
fix the #include paths relative to this repository

### DIFF
--- a/doc/Example.ahk
+++ b/doc/Example.ahk
@@ -1,6 +1,6 @@
-#Include <Yunit\Yunit>
-#Include <Yunit\Window>
-#Include <Yunit\StdOut>
+#Include ..\Yunit.ahk
+#Include ..\Window.ahk
+#Include ..\StdOut.ahk
 
 Yunit.Use(YunitStdOut, YunitWindow).Test(NumberTestSuite, StringTestSuite)
 


### PR DESCRIPTION
people should be able to run the Example.ahk file as-is
