### PR TITLE
Change successful test icon

### DIFF
--- a/Window.ahk
+++ b/Window.ahk
@@ -9,7 +9,7 @@ class YunitWindow
         hImageList := IL_Create()
         IL_Add(hImageList,"shell32.dll",132) ;red X
         IL_Add(hImageList,"shell32.dll",78) ;yellow triangle with exclamation mark
-        IL_Add(hImageList,"shell32.dll",138) ;green circle with arrow facing right
+        IL_Add(hImageList,"shell32.dll",147) ;green up arrow
         IL_Add(hImageList,"shell32.dll",135) ;two sheets of paper
         this.icons := {fail: "Icon1", issue: "Icon2", pass: "Icon3", detail: "Icon4"}
         

--- a/doc/Main.md
+++ b/doc/Main.md
@@ -114,7 +114,7 @@ The results are shown in the form of a tree control, with each test suite having
 
 Beside each node is an icon:
 
-* _Green circle with "play" symbol_ - test passed successfully.
+* _Green up arrow - test passed successfully.
 * _Yellow triangle with exclamation mark_ - test failed.
 * _Two papers_ - test result/description.
 


### PR DESCRIPTION
On Win10, icon #138 in shell32.dll is no longer a green
circle with an arrow facing right. They've changed it to
a blue arrow right.

Icon #147 is a green up arrow, and is consistent back thru
Win7. It seems as good of a choice as any.