### PR TITLE
Only expand failed categories

### DIFF
--- a/Window.ahk
+++ b/Window.ahk
@@ -55,10 +55,10 @@ class YunitWindow
                 pos := InStr(key, ".", false, (A_AhkVersion < "2") ? 0 : -1, 1)
                 key := SubStr(key, 1, pos-1)
             }
+            TV_Modify(Parent, "Expand")
         }
         Else
             TV_Add(TestName,Parent,this.icons.pass)
-        TV_Modify(Parent, "Expand")
         TV_Modify(TV_GetNext(), "VisFirst")   ;// scroll the treeview back to the top
     }
     

--- a/Window.ahk
+++ b/Window.ahk
@@ -51,7 +51,7 @@ class YunitWindow
             pos := 1
             while (pos)
             {
-                TV_Modify(this.Categories[key], this.icons.issue)
+                TV_Modify(this.Categories[key], "Expand " . this.icons.issue)
                 pos := InStr(key, ".", false, (A_AhkVersion < "2") ? 0 : -1, 1)
                 key := SubStr(key, 1, pos-1)
             }


### PR DESCRIPTION
Passed tests are of little interest. I have quite a few tests in my suite so far and it would be nice to only see failed tests expanded in order to get a quick overview and minimize scrolling.

Also, thanks for taking the time to make this fun testing framework, I've enjoyed playing with it.