### PR TITLE
Update for v2.0-a090+

### DIFF
--- a/Yunit.ahk
+++ b/Yunit.ahk
@@ -45,12 +45,12 @@ class Yunit
         environment := new cls() ; calls __New
         for k,v in cls
         {
-            if IsObject(v) && IsFunc(v) ;test
+            if Type(v) = "Func" ;test
             {
                 if (k = "Begin") or (k = "End")
                     continue
                 if ObjHasKey(cls,"Begin") 
-                && IsFunc(cls.Begin)
+                && Type(cls.Begin) = "Func"
                     environment.Begin()
                 result := 0
                 try
@@ -69,7 +69,7 @@ class Yunit
                 ObjDelete(environment, "ExpectedException")
                 this.Update(cls.__class, k, results[k])
                 if ObjHasKey(cls,"End")
-                && IsFunc(cls.End)
+                && Type(cls.End) = "Func"
                     environment.End()
             }
             else if IsObject(v)


### PR DESCRIPTION
IsFunc requires a function name in v2.0-a090+ and throws an exception if given an object. This was done to avoid the issue of Func vs. other callable objects. If you specifically require a Func object (i.e. with all its expected properties and methods), it is more appropriate to use an explicit type check. In general, my recommendation is to perform a type check only if absolutely necessary - so for instance, I might omit the type checks for Begin and End.
    
`Type(x) = "Func"` is the direct replacement for `IsObject(x) && IsFunc(x)`, but for more general values of x, the correct replacement would be `IsObject(x) ? Type(x) = "Func" : IsFunc(x)`. I chose to use the shorter, more restrictive (object-only) form for Begin/End since it seems unlikely one would be storing function names in the test suite object vs. defining methods. The check could be omitted since the test suite object will presumably only ever contain methods and classes intended for consumption by Yunit, but I suppose it's safer to keep the check.
    
`Type(x) = "Func"` (or previously `IsFunc(x)`) won't fully protect you against an invalid x: if x defines more mandatory parameters than you pass, your attempt to call will still throw an exception. What it will do is prevent the use of BoundFunc or user-defined objects.
