### PR TITLE
Fix unquoted attribute values

### DIFF
--- a/JUnit.ahk
+++ b/JUnit.ahk
@@ -25,9 +25,9 @@ class YunitJUnit{
     __Delete() {
 				file := FileOpen(this.filename, "w")
 				file.write("<?xml version=""1.0"" encoding=""UTF-8""?>`n")
-				msg := "<testsuites failures=" this.tests.fail " tests=" this.tests.overall ">"
+				msg := "<testsuites failures=""" this.tests.fail """ tests=""" this.tests.overall """>"
 				file.write(msg . "`n")
-				msg := "`t<testsuite failures=" this.tests.fail " tests=" this.tests.overall " name=""AHK_YUnit"">"
+				msg := "`t<testsuite failures=""" this.tests.fail """ tests=""" this.tests.overall """ name=""AHK_YUnit"">"
 				file.write(msg "`n")
 				Loop % this.out.Length()
 					file.write(this.out[A_Index] "`n")
@@ -40,7 +40,7 @@ class YunitJUnit{
     Update(Category, TestName, Result)
     {		
 				this.tests.overall := this.tests.overall + 1
-				msg := "`t`t<testcase name=""" TestName """ classname=""" Category ""
+				msg := "`t`t<testcase name=""" TestName """ classname=""" Category """"
         If IsObject(Result) {
 					this.out.Push(msg ">")
 					this.tests.fail := this.tests.fail + 1


### PR DESCRIPTION
Hey, the XML file generated by the JUnit module has some unquoted attribute values, which makes it incompatible with CI solutions

Here's the current output xml that is generated 
```xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuites failures=0 tests=7>
	<testsuite failures=0 tests=7 name="AHK_YUnit">
		<testcase name="VMType" classname="VMR_Test/>
		<testcase name="BusGain" classname="VMR_Test.Bus_Strip_Tests/>
		<testcase name="BusGainPercentage" classname="VMR_Test.Bus_Strip_Tests/>
		<testcase name="BusLimit" classname="VMR_Test.Bus_Strip_Tests/>
		<testcase name="BusMute" classname="VMR_Test.Bus_Strip_Tests/>
		<testcase name="StripColor" classname="VMR_Test.Bus_Strip_Tests/>
		<testcase name="StripLabel" classname="VMR_Test.Bus_Strip_Tests/>
	</testsuite>
</testsuites>
```

This commit should fix it completely

```xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuites failures="0" tests="7">
	<testsuite failures="0" tests="7" name="AHK_YUnit">
		<testcase name="VMType" classname="VMR_Test"/>
		<testcase name="BusGain" classname="VMR_Test.Bus_Strip_Tests"/>
		<testcase name="BusGainPercentage" classname="VMR_Test.Bus_Strip_Tests"/>
		<testcase name="BusLimit" classname="VMR_Test.Bus_Strip_Tests"/>
		<testcase name="BusMute" classname="VMR_Test.Bus_Strip_Tests"/>
		<testcase name="StripColor" classname="VMR_Test.Bus_Strip_Tests"/>
		<testcase name="StripLabel" classname="VMR_Test.Bus_Strip_Tests"/>
	</testsuite>
</testsuites>
```